### PR TITLE
Removed image height rule

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@ layout: default
     <p><strong><span style="font-size: 18pt;">Global Menu</span></strong><br />Cutefishos has a global menu at the top. It is a collection of all functions of an application, which is very convenient for the integration of apps functions with the system, and can save some screen space.</p>
   </div>
   <div class="column">
-    <img src="https://raw.githubusercontent.com/cutefish-ubuntu/cutefish-ubuntu.github.io/master/images/menubar.47ce40cd.png" alt="" width="100%" height="100%" />
+    <img src="https://raw.githubusercontent.com/cutefish-ubuntu/cutefish-ubuntu.github.io/master/images/menubar.47ce40cd.png" alt="" width="100%" />
   </div>
   </div>
 </div>


### PR DESCRIPTION
Before:
  height="100%" stretches out the image (Cutefish OS Global menu screenshot)
After:
  image is no longer stretched